### PR TITLE
Fix links to survivor images

### DIFF
--- a/build/buildPage.js
+++ b/build/buildPage.js
@@ -70,7 +70,7 @@ function parseCharacter(role, data, row, col) {
 	if (role === "killer") {
 		character.img = "https://deadbydaylight.wiki.gg" + killerImages.splice(0, 1);
 	} else {
-		character.img = survivorImages.splice(0, 1);
+		character.img = "" + survivorImages.splice(0, 1);
 	}
 	// Loop over columns (builds)
 	for (let i = 1; i < 8; i += 2) {

--- a/build/buildPage.js
+++ b/build/buildPage.js
@@ -70,7 +70,7 @@ function parseCharacter(role, data, row, col) {
 	if (role === "killer") {
 		character.img = "https://deadbydaylight.wiki.gg" + killerImages.splice(0, 1);
 	} else {
-		character.img = "https://deadbydaylight.wiki.gg" + survivorImages.splice(0, 1);
+		character.img = survivorImages.splice(0, 1);
 	}
 	// Loop over columns (builds)
 	for (let i = 1; i < 8; i += 2) {


### PR DESCRIPTION
Hi!

Links to the survivor images are broken.

![image](https://github.com/user-attachments/assets/289ec963-281b-486b-b8f3-557d50b7a028)

The bug is caused by adding the `deadbydaylight.wiki.gg` domain to the links, so right now they look like this: `https://deadbydaylight.wiki.ggimg/OtzZarina.png`.

Since the survivor images are stored directly in the repository, all you need to do is delete the domain for them.

*P.S. I don't know what this change is on line 123. It was done automatically by GitHub's built-in editor, which I used to create the commit.*