### PR TITLE
Fix killer names

### DIFF
--- a/build/getPerks.js
+++ b/build/getPerks.js
@@ -4,6 +4,7 @@ const axios = require("axios").default;
 
 // Parse perks from the wikipedia perk tables
 async function parsePerks(url) {
+	const isKiller = url.indexOf("Killer") !== -1;
 	const stuff = await axios.get(url);
 	const dom = new JSDOM(stuff.data);
 	const { document } = dom.window;
@@ -20,7 +21,7 @@ async function parsePerks(url) {
 				perkName: imageElement?.alt,
 				// Description is URI encoded for simplicity
 				description: encodeURI(x.children[2].innerHTML.replaceAll("/wiki/", "https://deadbydaylight.wiki.gg/wiki/")),
-				character: x.children[3].querySelector("a")?.title,
+				character: isKiller ? x.children[3].querySelector("a")?.textContent : x.children[3].querySelector("a")?.title,
 				characterImage: x.children[3].querySelector("img")?.src
 			}
 		});


### PR DESCRIPTION
Some pages in deadbydaylight.wiki.gg use the killer's full name instead of their "stage name" (example: https://deadbydaylight.wiki.gg/wiki/Kenneth_Chase_alias_Jeffrey_Hawk).

This results in those names being displayed in an unintended way, as can be seen here:
<img width="469" height="111" alt="Screenshot_20260101_164516" src="https://github.com/user-attachments/assets/21ec96d0-496b-41d9-8a67-55df3d04e6eb" />
I assume that what you want here is always the "stage name" instead of the full name, given that you prefix the name with "the" if the given character is a killer.

This PR changes the logic to use the text content of the link instead of the `title` property, which is always the "stage name", as intended.